### PR TITLE
Fixes #30 nested ternary operator without explicit parentheses deprecated in PHP 7.4

### DIFF
--- a/asyncjsDashboardScreens.php
+++ b/asyncjsDashboardScreens.php
@@ -11,7 +11,7 @@ $aj_enabled = ( get_option( 'aj_enabled', 0 ) == 1 ) ? 'Enabled' : 'Disabled';
 $aj_method = ( get_option( 'aj_method', 'async' ) == 'async' ) ? 'Async' : 'Defer';
 $aj_jquery = get_option( 'aj_jquery', 'async' );
 $aj_jquery = ( $aj_jquery == 'same ' ) ? get_option( 'aj_method', 'async' ) : $aj_jquery;
-$aj_jquery = ( $aj_jquery == 'async' ) ? 'Async' : ( $aj_jquery == 'defer' ) ? 'Defer' : 'Excluded';
+$aj_jquery = ( $aj_jquery == 'async' ) ? 'Async' : (( $aj_jquery == 'defer' ) ? 'Defer' : 'Excluded');
 $aj_exclusions = get_option( 'aj_exclusions', '' );
 $aj_plugin_exclusions = get_option( 'aj_plugin_exclusions', array() );
 $aj_theme_exclusions = get_option( 'aj_theme_exclusions', array() );


### PR DESCRIPTION
https://github.com/futtta/async-javascript/issues/30